### PR TITLE
Extend Bylaws Revision Period

### DIFF
--- a/Bylaws.md
+++ b/Bylaws.md
@@ -167,6 +167,6 @@
     <li>The purpose and effect of an amendment must remain consistent between the two amending motions, though narrowly tailored or grammatical changes are permitted.</li>
     <li>A <a href="https://github.com/NPD-Admin/Non-Partisan-Delaware-Documents">change log</a> shall be maintained tracing all amendments to these Bylaws and retaining copies of previous versions.  This change log shall be publicly accessible.</li>
     <li>The <a href="https://github.com/NPD-Admin/Non-Partisan-Delaware-Documents/blob/main/Bylaws.md">most recent version of the Bylaws</a> should include links to the resources described by them once those resources are created and approved by the Governing Board.</li>
-    <li>For the first year of Non-Partisan Delaware’s operations, amending the Bylaws shall only require a single 2/3rds vote of the Governing Board, irrespective of all other requirements.  This section shall be automatically deleted at the end of that year.</li>
+    <li>For the first two years of Non-Partisan Delaware’s operations, amending the Bylaws shall only require a single 2/3rds vote of the Governing Board, irrespective of all other requirements.  This section shall be automatically deleted at the end of that year.</li>
   </ol>
 </ol>


### PR DESCRIPTION
The initial bylaws for NPD allowed a simplified revision/amendment process for the first year of operations.  That year expires on June 19th and while we have made several revisions to the bylaws in the last few months, we still have at least two that need to happen as relates to off-year nominations and our own initial election process.

That's before we even touch on the fact that our Strategic Plan lists a thorough review of our bylaws as an organizational goal and most of our bylaws provisions have not been tested in production yet, or even critically examined since their initial drafting and review prior to our official formation.

We need more time to be able to tweak these without the full blown amendment process being necessary, and our membership is still small enough that this kind of notification and review process is superfluous.